### PR TITLE
added Cypress tests for emit and watch invalid dates and emitted events

### DIFF
--- a/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.js
+++ b/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.js
@@ -9,7 +9,7 @@
  * </tbody>
  * </table>
  * 
- * @vue-prop {String} setDate - the initial date to be displayed in the component (YYYY-MM-DD).
+ * @vue-prop {String} setDate - the prop date to be displayed in the component (YYYY-MM-DD).
  * @vue-prop {String} [earliestDate] - the earliest date will be able to be chosen (YYYY-MM-DD).  If not specified, there will be no limit on the earliest date that can be chosen.
  * @vue-prop {String} [latestDate] - the latest date that will be able to be chosen (YYYY-MM-DD). If not specfied, there will be no limit (including future dates) that can be chosen.
  * 
@@ -39,7 +39,7 @@ let DateSelectionComponent = {
         } 
     },
     mounted() {
-        this.$emit('date-changed', this.selectedDate)
+        this.checkBounds()
     },
     methods: {
         click(){
@@ -57,7 +57,8 @@ let DateSelectionComponent = {
     },
     watch: {
         setDate(newDate) {
-            this.selectedDate = newDate
+            this.selectedDate = newDate;
+            this.checkBounds();
         }
     }
     

--- a/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.js
+++ b/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.js
@@ -9,12 +9,12 @@
  * </tbody>
  * </table>
  * 
- * @vue-prop {String} setDate - the prop date to be displayed in the component (YYYY-MM-DD).
+ * @vue-prop {String} setDate - the date to be displayed in the component (YYYY-MM-DD).
  * @vue-prop {String} [earliestDate] - the earliest date will be able to be chosen (YYYY-MM-DD).  If not specified, there will be no limit on the earliest date that can be chosen.
  * @vue-prop {String} [latestDate] - the latest date that will be able to be chosen (YYYY-MM-DD). If not specfied, there will be no limit (including future dates) that can be chosen.
  * 
  * @vue-event click - Emits an event with no payload when when the date input element is clicked.  This event does not necessarily indicate a change in date.
- * @vue-event {String} date-changed - Emits the selected date (YYYY-MM-DD) when a date is entered or chosen and the date input element loses focus.
+ * @vue-event {String} date-changed - Emits the selected date (YYYY-MM-DD) when a date is entered, chosen, setDate in prop is changed by the parent, the component is mounted, and the date input element loses focus.
  */ 
 let DateSelectionComponent = {
     template: `<span>

--- a/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.spec.comp.js
+++ b/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.spec.comp.js
@@ -77,13 +77,22 @@ describe('date selection component', () => {
             })
         })
         
-
         it ('change setDate prop to 2021-08-09', () => {
             expect(comp.vm.selectedDate).to.equal('2021-07-09')
             cy.wrap(comp.setProps({ setDate: '2021-08-09' }))
             .then(() => {
                   expect(comp.vm.selectedDate).to.equal('2021-08-09')
             })
+        })
+
+        it ('change setDate prop to an invalid date of 2022-12-01', () => {
+            expect(comp.vm.selectedDate).to.equal('2021-08-09')
+            cy.wrap(comp.setProps({ setDate: '2022-12-01' }))
+            .then(() => {
+                  expect(comp.vm.selectedDate).to.equal('2021-12-31')
+            })
+
+        
         })
     })
 

--- a/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.spec.comp.js
+++ b/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.spec.comp.js
@@ -81,24 +81,42 @@ describe('date selection component', () => {
             expect(comp.vm.selectedDate).to.equal('2021-07-09')
             cy.wrap(comp.setProps({ setDate: '2021-08-09' }))
             .then(() => {
-                  expect(comp.vm.selectedDate).to.equal('2021-08-09')
+                expect(comp.vm.selectedDate).to.equal('2021-08-09')
             })
         })
 
-        it ('change setDate prop to an invalid date of 2022-12-01', () => {
-            expect(comp.vm.selectedDate).to.equal('2021-08-09')
+        it ('change setDate prop to date after latestDate, which will set to latestDate', () => {
+            expect(comp.vm.selectedDate).to.equal('2021-07-09')
             cy.wrap(comp.setProps({ setDate: '2022-12-01' }))
             .then(() => {
-                  expect(comp.vm.selectedDate).to.equal('2021-12-31')
+                expect(comp.vm.selectedDate).to.equal('2021-12-31')
             })
-
-        
         })
+        it ('change setDate prop to date before earliestDate, which will set to earliestDate', () => {
+            expect(comp.vm.selectedDate).to.equal('2021-07-09')
+            cy.wrap(comp.setProps({ setDate: '1999-12-01' }))
+            .then(() => {
+                expect(comp.vm.selectedDate).to.equal('2021-01-01')
+            })
+        })
+
     })
 
-    context('mount event tests', () => {
+    context('emitted event tests', () => {
         let prop = {
             setDate: "2021-08-09",
+            latestDate: "2021-12-31",
+            earliestDate: "2021-01-01"
+        }
+
+        let propInvalidEarliest = {
+            setDate: "1999-05-01",
+            latestDate: "2021-12-31",
+            earliestDate: "2021-01-01"
+        }
+
+        let propInvalidLatest = {
+            setDate: "2035-05-01",
             latestDate: "2021-12-31",
             earliestDate: "2021-01-01"
         }
@@ -112,12 +130,77 @@ describe('date selection component', () => {
                 }
             })
             .then(() => {
-                    expect(spy).to.be.calledWith('2021-08-09')
+                expect(spy).to.be.calledWith('2021-08-09')
+            })
+        })
+
+        it('emits correct date after the component is mounted with invalid date(< than earliestDate)', () => {   
+            const spy = cy.spy()
+            mount(DateSelectionComponent, {
+                propsData: propInvalidEarliest,
+                listeners: {
+                    'date-changed': spy
+                }
+            })
+            .then(() => {
+                expect(spy).to.be.calledWith('2021-01-01')
+            })
+        })
+
+        it('emits correct date after the component is mounted with invalid date(> than latestDate)', () => {   
+            const spy = cy.spy()
+            mount(DateSelectionComponent, {
+                propsData: propInvalidLatest,
+                listeners: {
+                    'date-changed': spy
+                }
+            })
+            .then(() => {
+                expect(spy).to.be.calledWith('2021-12-31')
+            })
+        })
+
+        it('emits date after the prop is changed', () => {   
+            const spy = cy.spy()
+            let comp = shallowMount(DateSelectionComponent, {
+                propsData: prop,
+                listeners: {
+                    'date-changed': spy
+                }
+            })
+            cy.wrap(comp.setProps({ setDate: '2021-08-09' }))
+            .then(() => {
+                expect(spy).to.be.calledWith('2021-08-09')
+            })
+        })
+
+        it('emits correct date after the prop is changed to invalid date(< than earliestDate)', () => {   
+            const spy = cy.spy()
+            let comp = shallowMount(DateSelectionComponent, {
+                propsData: prop,
+                listeners: {
+                    'date-changed': spy
+                }
+            })
+            cy.wrap(comp.setProps({ setDate: '2000-08-09' }))
+            .then(() => {
+                expect(spy).to.be.calledWith('2021-01-01')
+            })
+        })
+
+        it('emits correct date after the prop is changed to invalid date(> than latestDate)', () => {   
+            const spy = cy.spy()    
+            let comp = shallowMount(DateSelectionComponent, {
+                propsData: prop,
+                listeners: {
+                    'date-changed': spy
+                }
+            })
+            cy.wrap(comp.setProps({ setDate: '2029-08-09' }))
+            .then(() => {
+                expect(spy).to.be.calledWith('2021-12-31')
             })
         })
 
     })
-
 })
-
-


### PR DESCRIPTION
__Pull Request Description__

added Cypress tests for emit and watch invalid dates and emitted events

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
